### PR TITLE
Remove dropping of non-existent type

### DIFF
--- a/db/migrate/20160523211642_initial_tables.rb
+++ b/db/migrate/20160523211642_initial_tables.rb
@@ -91,6 +91,5 @@ class InitialTables < ActiveRecord::Migration
 
     execute_on_all_nodes 'DROP TYPE campaign_cost_model'
     execute_on_all_nodes 'DROP TYPE campaign_state'
-    execute_on_all_nodes 'DROP TYPE campaign_budget_interval'
   end
 end


### PR DESCRIPTION
The type campaign_budget_interval has never been created and thus running
the down migration throws an error.